### PR TITLE
Move label to device

### DIFF
--- a/benchmarks/rnnt/ootb/train/rnnt/model.py
+++ b/benchmarks/rnnt/ootb/train/rnnt/model.py
@@ -256,6 +256,8 @@ def label_collate(labels):
     Returns:
         A padded torch.Tensor of shape (batch, max_seq_len).
     """
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    labels = labels.to(device)
 
     if isinstance(labels, torch.Tensor):
         return labels.type(torch.int64)


### PR DESCRIPTION
Inspection of the RNNT model found that not all tensors are ran on device before the encode/predict calls in forward pass. 
Loading tensor into device provides a 2% performance improvement. 


<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/adabeyta/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/adabeyta/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{border:.5pt solid windowtext;}
.xl66
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl67
	{border:.5pt solid windowtext;}
.xl68
	{mso-number-format:0%;
	border:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



ROCM   5.4  \| UBB4 | Performance   (ex/sec)
-- | --
Collate to   device | 3642.300883
Collate   onlycpu | 3576.016631
Difference | 66.28425156
% Boost | 2%



</body>

</html>

Performance values were taken from a 3 run average. 